### PR TITLE
add min_level configuration option

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,8 +2,11 @@ import esphome.config_validation as cv
 import esphome.codegen as cg
 from esphome import automation
 from esphome.const import CONF_ID, CONF_IP_ADDRESS, CONF_PORT, CONF_CLIENT_ID, CONF_LEVEL, CONF_PAYLOAD, CONF_TAG
+from esphome.components.logger import LOG_LEVELS, is_log_level
+
 CONF_STRIP_COLORS = "strip_colors"
 CONF_ENABLE_LOGGER_MESSAGES = "enable_logger"
+CONF_MIN_LEVEL = "min_level"
 
 DEPENDENCIES = ['logger','network']
 
@@ -19,6 +22,7 @@ CONFIG_SCHEMA = cv.Schema({
     cv.Optional(CONF_PORT, default=514): cv.port,
     cv.Optional(CONF_ENABLE_LOGGER_MESSAGES, default=True): cv.boolean,
     cv.Optional(CONF_STRIP_COLORS, default=True): cv.boolean,
+    cv.Optional(CONF_MIN_LEVEL, default="DEBUG"): is_log_level,
 })
 
 SYSLOG_LOG_ACTION_SCHEMA = cv.Schema({
@@ -38,6 +42,7 @@ def to_code(config):
     cg.add(var.set_strip_colors(config[CONF_STRIP_COLORS]))
     cg.add(var.set_server_ip(config[CONF_IP_ADDRESS]))
     cg.add(var.set_server_port(config[CONF_PORT]))
+    cg.add(var.set_min_log_level(LOG_LEVELS[config[CONF_MIN_LEVEL]]))
 
 @automation.register_action('syslog.log', SyslogLogAction, SYSLOG_LOG_ACTION_SCHEMA)
 def syslog_log_action_to_code(config, action_id, template_arg, args):

--- a/syslog_component.cpp
+++ b/syslog_component.cpp
@@ -52,15 +52,17 @@ void SyslogComponent::loop() {
 void SyslogComponent::log(uint8_t level, const std::string &tag, const std::string &payload) {
     level = level > 7 ? 7 : level;
 
-    Syslog syslog(
-        *this->udp_,
-        this->settings_.address.c_str(),
-        this->settings_.port,
-        this->settings_.client_id.c_str(),
-        tag.c_str(),
-        LOG_KERN
-    );
-    syslog.log(esphome_to_syslog_log_levels[level],  payload.c_str());
+    if (level <= this->settings_.min_log_level) {
+        Syslog syslog(
+            *this->udp_,
+            this->settings_.address.c_str(),
+            this->settings_.port,
+            this->settings_.client_id.c_str(),
+            tag.c_str(),
+            LOG_KERN
+        );
+        syslog.log(esphome_to_syslog_log_levels[level],  payload.c_str());
+    }
 }
 
 float SyslogComponent::get_setup_priority() const {

--- a/syslog_component.h
+++ b/syslog_component.h
@@ -17,6 +17,7 @@ struct SYSLOGSettings {
     std::string address;
     uint16_t port;
     std::string client_id;
+    int min_log_level;
 };
 
 //class UDP;
@@ -33,6 +34,7 @@ class SyslogComponent : public Component  {
         void set_server_ip(const std::string &address)        { this->settings_.address   = address; }
         void set_server_port(uint16_t port)                   { this->settings_.port      = port; }
         void set_client_id(const std::string &client_id)      { this->settings_.client_id = client_id; }
+        void set_min_log_level(int log_level)                 { this->settings_.min_log_level = log_level; }
 
         void set_enable_logger_messages(bool en) { this->enable_logger = en; }
         void set_strip_colors(bool strip_colors) { this->strip_colors = strip_colors; }


### PR DESCRIPTION
This PR allows to specify a minimum severity level for logger messages to be forwarded via syslog.

E.g. the following will only syslog logger messages with severity INFO and higher:

```
syslog:
    ip_address: "192.168.1.53"
    min_level: INFO
```
