### PR TITLE
Fix esp-idf and IPv6 support by using plain UDP socket, drop Syslog library

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 A simple syslog component for esphome. The component is designed to auto attach itself to the logger core module (like the MQTT component does with the `log_topic`)
 
-This component uses the https://github.com/arcao/Syslog library version 2.0 at its core
-
 ## How to
 
 ### Manually

--- a/components/syslog/__init__.py
+++ b/components/syslog/__init__.py
@@ -8,7 +8,7 @@ CONF_STRIP_COLORS = "strip_colors"
 CONF_ENABLE_LOGGER_MESSAGES = "enable_logger"
 CONF_MIN_LEVEL = "min_level"
 
-DEPENDENCIES = ['logger','network']
+DEPENDENCIES = ['logger','network','socket']
 
 debug_ns = cg.esphome_ns.namespace('debug')
 syslog_ns = cg.esphome_ns.namespace('syslog')
@@ -16,17 +16,14 @@ syslog_ns = cg.esphome_ns.namespace('syslog')
 SyslogComponent = syslog_ns.class_('SyslogComponent', cg.Component)
 SyslogLogAction = syslog_ns.class_('SyslogLogAction', automation.Action)
 
-CONFIG_SCHEMA = cv.All(
-    cv.Schema({
-        cv.GenerateID(): cv.declare_id(SyslogComponent),
-        cv.Optional(CONF_IP_ADDRESS, default="255.255.255.255"): cv.string_strict,
-        cv.Optional(CONF_PORT, default=514): cv.port,
-        cv.Optional(CONF_ENABLE_LOGGER_MESSAGES, default=True): cv.boolean,
-        cv.Optional(CONF_STRIP_COLORS, default=True): cv.boolean,
-        cv.Optional(CONF_MIN_LEVEL, default="DEBUG"): is_log_level,
-    }),
-    cv.only_with_arduino,
-)
+CONFIG_SCHEMA = cv.Schema({
+    cv.GenerateID(): cv.declare_id(SyslogComponent),
+    cv.Optional(CONF_IP_ADDRESS, default="255.255.255.255"): cv.string_strict,
+    cv.Optional(CONF_PORT, default=514): cv.port,
+    cv.Optional(CONF_ENABLE_LOGGER_MESSAGES, default=True): cv.boolean,
+    cv.Optional(CONF_STRIP_COLORS, default=True): cv.boolean,
+    cv.Optional(CONF_MIN_LEVEL, default="DEBUG"): is_log_level,
+})
 
 SYSLOG_LOG_ACTION_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.use_id(SyslogComponent),
@@ -36,8 +33,6 @@ SYSLOG_LOG_ACTION_SCHEMA = cv.Schema({
 })
 
 def to_code(config):
-    cg.add_library('Syslog', '2.0.0')
-
     var = cg.new_Pvariable(config[CONF_ID])
     yield cg.register_component(var, config)
     

--- a/components/syslog/syslog_component.cpp
+++ b/components/syslog/syslog_component.cpp
@@ -102,6 +102,8 @@ void SyslogComponent::log(uint8_t level, const std::string &tag, const std::stri
     if (this->is_failed())
         return;
 
+    level = level > 7 ? 7 : level;
+
     if (!this->socket_) {
         ESP_LOGW(TAG, "Tried to send \"%s\"@\"%s\" with level %d but socket isn't connected", tag.c_str(), payload.c_str(), level);
         return;

--- a/components/syslog/syslog_component.cpp
+++ b/components/syslog/syslog_component.cpp
@@ -12,6 +12,11 @@
 #include "esphome/core/defines.h"
 */
 
+#ifdef USE_SOCKET_IMPL_LWIP_TCP
+#include <lwip/ip.h>
+#define IPPROTO_UDP IP_PROTO_UDP
+#endif
+
 namespace esphome {
 namespace syslog {
 
@@ -59,12 +64,14 @@ void SyslogComponent::setup() {
         this->server_socklen = sizeof(*server4);
     }
     if (!this->server_socklen) {
-        ESP_LOGW(TAG, "Failed to parse server IP address '%s'", this->settings_.address.c_str());
+        ESP_LOGE(TAG, "Failed to parse server IP address '%s'", this->settings_.address.c_str());
+        this->mark_failed();
         return;
     }
     this->socket_ = socket::socket(this->server.ss_family, SOCK_DGRAM, IPPROTO_UDP);
     if (!this->socket_) {
-        ESP_LOGW(TAG, "Failed to create UDP socket");
+        ESP_LOGE(TAG, "Failed to create UDP socket");
+        this->mark_failed();
         return;
     }
 
@@ -91,6 +98,9 @@ void SyslogComponent::loop() {
 
 void SyslogComponent::log(uint8_t level, const std::string &tag, const std::string &payload) {
     level = level > 7 ? 7 : level;
+
+    if (this->is_failed())
+        return;
 
     if (!this->socket_) {
         ESP_LOGW(TAG, "Tried to send \"%s\"@\"%s\" with level %d but socket isn't connected", tag.c_str(), payload.c_str(), level);

--- a/components/syslog/syslog_component.cpp
+++ b/components/syslog/syslog_component.cpp
@@ -97,7 +97,6 @@ void SyslogComponent::loop() {
 }
 
 void SyslogComponent::log(uint8_t level, const std::string &tag, const std::string &payload) {
-    level = level > 7 ? 7 : level;
 
     if (this->is_failed())
         return;

--- a/components/syslog/syslog_component.h
+++ b/components/syslog/syslog_component.h
@@ -6,16 +6,7 @@
 #include "esphome/core/defines.h"
 #include "esphome/core/automation.h"
 #include "esphome/core/log.h"
-#include <Syslog.h>
-#include <Udp.h>
-
-#if defined ESP8266 || defined ARDUINO_ESP8266_ESP01
-    #include <ESP8266WiFi.h>
-#else
-    #include <WiFi.h>
-#endif
-
-#include <WiFiUdp.h>
+#include "esphome/components/socket/socket.h"
 
 namespace esphome {
 namespace syslog {
@@ -51,7 +42,9 @@ class SyslogComponent : public Component  {
         bool strip_colors;
         bool enable_logger;
         SYSLOGSettings settings_;
-        UDP *udp_ = NULL;
+        std::unique_ptr<socket::Socket> socket_ = nullptr;
+        struct sockaddr_storage server;
+        socklen_t server_socklen;
 };
 
 template<typename... Ts> class SyslogLogAction : public Action<Ts...> {


### PR DESCRIPTION
It turns out to be fairly simple to just send the UDP packets directly, and the UDP socket handling can then be a whole lot more generic.